### PR TITLE
fix: use Maven image for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,26 @@
 # Dockerfile para Wallet API
-FROM openjdk:17-jdk-slim as builder
+FROM maven:3.9.6-eclipse-temurin-17 AS builder
 
 # Informações do build
 LABEL maintainer="hlaff@example.com"
 LABEL version="1.0.0"
 LABEL description="Wallet API - Sistema de carteiras digitais"
 
-# Instalar dependências necessárias
-RUN apt-get update && apt-get install -y \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
-
 # Definir diretório de trabalho
 WORKDIR /app
 
-# Copiar arquivos de configuração do Maven
-COPY .mvn/ .mvn/
-COPY mvnw pom.xml ./
-
-# Download das dependências (cache layer)
-RUN chmod +x ./mvnw
-RUN ./mvnw dependency:go-offline -BB
+# Copiar POM e baixar dependências (cache layer)
+COPY pom.xml ./
+RUN mvn -B dependency:go-offline
 
 # Copiar código fonte
 COPY src/ src/
 
 # Build da aplicação
-RUN ./mvnw clean package -DskipTests -B && \
+RUN mvn -B -DskipTests clean package && \
     java -Djarmode=layertools -jar target/*.jar extract
 
 # Runtime stage
-FROM eclipse-temurin:17-jdk
 FROM eclipse-temurin:17-jre
 # Instalar curl para health checks
 RUN apt-get update && apt-get install -y \
@@ -44,10 +34,10 @@ RUN groupadd -r wallet && useradd -r -g wallet wallet
 WORKDIR /app
 
 # Copiar layers da aplicação para otimizar cache
-COPY --from=builder --chown=wallet:wallet app/dependencies/ ./
-COPY --from=builder --chown=wallet:wallet app/spring-boot-loader/ ./
-COPY --from=builder --chown=wallet:wallet app/snapshot-dependencies/ ./
-COPY --from=builder --chown=wallet:wallet app/application/ ./
+COPY --from=builder --chown=wallet:wallet /app/dependencies/ ./
+COPY --from=builder --chown=wallet:wallet /app/spring-boot-loader/ ./
+COPY --from=builder --chown=wallet:wallet /app/snapshot-dependencies/ ./
+COPY --from=builder --chown=wallet:wallet /app/application/ ./
 
 # Mudar para usuário não-root
 USER wallet


### PR DESCRIPTION
## Summary
- use Maven 3.9 Temurin 17 image for builder stage
- run mvn commands directly and clean up runtime image

## Testing
- `mvn test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aba276e4848324a1306b06f3fac385